### PR TITLE
Fix: Generalize slow-growth logic in integrator.py

### DIFF
--- a/simulation/slow_growth/integrator.py
+++ b/simulation/slow_growth/integrator.py
@@ -248,8 +248,11 @@ class NoseHoover(MolecularDynamics):
         self.lagrange = np.zeros(len(self.constraints))
         if self.constraints and len(self.constraints[0]) > 0: 
             vel_half, converged = self.constrained_md()
-            self.constraints[0][3] = self.constraints[0][3] + self.increm
-            print("distance: " + str(self.constraints[0][3]))
+            #self.constraints[0][3] = self.constraints[0][3] + self.increm
+            #print("distance: " + str(self.constraints[0][3]))
+            for c in self.constraints:
+                c[-1] += self.increm
+            print("distance: " + str(self.constraints[0][-1]))
 
         self.cvgd.append(converged)
         self.atoms.set_velocities(vel_half)


### PR DESCRIPTION
The slow-growth logic was hardcoded to update `constraint[3]`, which caused an `IndexError` for non-type-0 constraints by corrupting an atom ID into a float.

This fix updates the last element (`[-1]`) of all constraints in a loop, ensuring the target value is always correctly modified.